### PR TITLE
Centralize reusable versions in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,23 +24,44 @@
 		<codeReviewPluginVersion>${code.review.plugin.version}</codeReviewPluginVersion>
 		<fcUnitPluginVersion>${fcunit.plugin.version}</fcUnitPluginVersion>
 
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <bw.maven.plugin.version>2.3.3</bw.maven.plugin.version>
-        <code.review.plugin.version>2.0.0</code.review.plugin.version>
-        <fcunit.plugin.version>2.0.0</fcunit.plugin.version>
-        <xmlunit.version>2.10.4</xmlunit.version>
-        <wagon.webdav.version>3.5.3</wagon.webdav.version>
-        <maven.site.plugin.version>3.21.0</maven.site.plugin.version>
-        <maven.project.info.reports.plugin.version>3.9.0</maven.project.info.reports.plugin.version>
-        <maven.dependency.plugin.version>${maven.project.info.reports.plugin.version}</maven.dependency.plugin.version>
-        <maven.plugin.plugin.version>3.15.1</maven.plugin.plugin.version>
-        <maven.plugin.tools.version>3.15.1</maven.plugin.tools.version>
-        <maven.javadoc.plugin.version>3.12.0</maven.javadoc.plugin.version>
-        <maven.core.version>3.9.11</maven.core.version>
-        <maven.resources.source.plugin.version>3.3.1</maven.resources.source.plugin.version>
-        <maven.scm.version>2.2.1</maven.scm.version>
-        <tibco.hawk.version>4.9</tibco.hawk.version>
-        <tibco.rv.version>8.3</tibco.rv.version>
+                <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+                <bw.maven.plugin.version>2.3.3</bw.maven.plugin.version>
+                <code.review.plugin.version>2.0.0</code.review.plugin.version>
+                <fcunit.plugin.version>2.0.0</fcunit.plugin.version>
+                <xmlunit.version>2.10.4</xmlunit.version>
+                <wagon.webdav.version>3.5.3</wagon.webdav.version>
+                <maven.site.plugin.version>3.21.0</maven.site.plugin.version>
+                <maven.project.info.reports.plugin.version>3.9.0</maven.project.info.reports.plugin.version>
+                <maven.dependency.plugin.version>${maven.project.info.reports.plugin.version}</maven.dependency.plugin.version>
+                <maven.plugin.plugin.version>3.15.1</maven.plugin.plugin.version>
+                <maven.plugin.tools.version>3.15.1</maven.plugin.tools.version>
+                <maven.javadoc.plugin.version>3.12.0</maven.javadoc.plugin.version>
+                <maven.release.plugin.version>3.12.0</maven.release.plugin.version>
+                <maven.core.version>3.9.11</maven.core.version>
+                <maven.resources.source.plugin.version>3.3.1</maven.resources.source.plugin.version>
+                <maven.scm.version>2.2.1</maven.scm.version>
+                <maven.scm.publish.plugin.version>3.3.0</maven.scm.publish.plugin.version>
+                <maven.compiler.plugin.version>3.14.1</maven.compiler.plugin.version>
+                <maven.deploy.plugin.version>3.1.4</maven.deploy.plugin.version>
+                <maven.antrun.plugin.version>3.1.0</maven.antrun.plugin.version>
+                <maven.gpg.plugin.version>3.2.8</maven.gpg.plugin.version>
+                <maven.enforcer.plugin.version>3.6.1</maven.enforcer.plugin.version>
+                <license.maven.plugin.version>5.0.0</license.maven.plugin.version>
+                <jaxws.maven.plugin.version>4.0.3</jaxws.maven.plugin.version>
+                <doxia.module.markdown.version>2.0.0</doxia.module.markdown.version>
+                <junit.version>4.13.2</junit.version>
+                <commons.exec.version>1.5.0</commons.exec.version>
+                <commons.io.version>2.20.0</commons.io.version>
+                <commons.configuration2.version>2.12.0</commons.configuration2.version>
+                <commons.collections4.version>4.5.0</commons.collections4.version>
+                <ojdbc8.version>21.19.0.0</ojdbc8.version>
+                <j2html.version>1.6.0</j2html.version>
+                <joox.version>2.0.1</joox.version>
+                <xerces.version>2.12.2</xerces.version>
+                <xalan.version>2.7.3</xalan.version>
+                <plexus.utils.version>4.0.2</plexus.utils.version>
+                <tibco.hawk.version>4.9</tibco.hawk.version>
+                <tibco.rv.version>8.3</tibco.rv.version>
 
 		<repositoryReleaseURL>${settingsRepositoryReleaseURL}</repositoryReleaseURL>
 		<repositorySnapshotURL>${settingsRepositorySnapshotURL}</repositorySnapshotURL>
@@ -194,7 +215,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-scm-publish-plugin</artifactId>
-                        <version>3.3.0</version>
+                        <version>${maven.scm.publish.plugin.version}</version>
                         <configuration>
                             <scmUrl>scm:git:${repositorySiteURL}</scmUrl>
                             <pubScmUrl>scm:git:${repositorySiteURL}</pubScmUrl>
@@ -313,7 +334,7 @@
                                 <dependency>
                                     <groupId>org.apache.maven.doxia</groupId>
                                     <artifactId>doxia-module-markdown</artifactId>
-                                    <version>2.0.0</version>
+                                    <version>${doxia.module.markdown.version}</version>
                                 </dependency>
 								<!-- add support for WebDAV -->
 								<dependency>
@@ -417,7 +438,7 @@
                         <plugin>
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-antrun-plugin</artifactId>
-                            <version>3.1.0</version>
+                            <version>${maven.antrun.plugin.version}</version>
                             <executions>
                                 <execution>
                                     <id>replace-site-url</id>
@@ -482,7 +503,7 @@
 					<plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.2.8</version>
+                        <version>${maven.gpg.plugin.version}</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>
@@ -530,11 +551,11 @@
 	<!-- Defines default version for most used dependencies -->
 	<dependencyManagement>
 		<dependencies>
-			<dependency> <!-- TODO Use junit-jupiter-api-->
-				<groupId>junit</groupId>
-				<artifactId>junit</artifactId>
-				<version>4.13.2</version>
-			</dependency>
+                        <dependency> <!-- TODO Use junit-jupiter-api-->
+                                <groupId>junit</groupId>
+                                <artifactId>junit</artifactId>
+                                <version>${junit.version}</version>
+                        </dependency>
 			<dependency>
 			<groupId>org.xmlunit</groupId>
 				<artifactId>xmlunit-core</artifactId>
@@ -548,29 +569,29 @@
 				<scope>test</scope>
 			</dependency>
 			<dependency>
-				<groupId>org.apache.commons</groupId>
-				<artifactId>commons-exec</artifactId>
-				<version>1.5.0</version>
+                                <groupId>org.apache.commons</groupId>
+                                <artifactId>commons-exec</artifactId>
+                                <version>${commons.exec.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>commons-io</groupId>
-				<artifactId>commons-io</artifactId>
-				<version>2.20.0</version>
+                                <groupId>commons-io</groupId>
+                                <artifactId>commons-io</artifactId>
+                                <version>${commons.io.version}</version>
 			</dependency>
 			<dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-configuration2</artifactId>
-                <version>2.12.0</version>
+                <version>${commons.configuration2.version}</version>
 			</dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-collections4</artifactId>
-                <version>4.5.0</version>
+                <version>${commons.collections4.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.oracle.database.jdbc</groupId>
                 <artifactId>ojdbc8</artifactId>
-                <version>21.19.0.0</version>
+                <version>${ojdbc8.version}</version>
             </dependency>
 <!--			<dependency>
 				<groupId>org.rendersnake</groupId>
@@ -580,12 +601,12 @@
             <dependency>
                 <groupId>com.j2html</groupId>
                 <artifactId>j2html</artifactId>
-                <version>1.6.0</version>
+                <version>${j2html.version}</version>
             </dependency>
 			<dependency>
-				<groupId>org.jooq</groupId>
-				<artifactId>joox</artifactId>
-				<version>2.0.1</version>
+                                <groupId>org.jooq</groupId>
+                                <artifactId>joox</artifactId>
+                                <version>${joox.version}</version>
 			</dependency>
             <!--<dependency>
 				<groupId>com.github.goldin</groupId>
@@ -593,14 +614,14 @@
 				<version>0.2.5</version>
 			</dependency>-->
 			<dependency>
-				<groupId>xerces</groupId>
-				<artifactId>xercesImpl</artifactId>
-				<version>2.12.2</version>
+                                <groupId>xerces</groupId>
+                                <artifactId>xercesImpl</artifactId>
+                                <version>${xerces.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>xalan</groupId>
-				<artifactId>xalan</artifactId>
-				<version>2.7.3</version>
+                                <groupId>xalan</groupId>
+                                <artifactId>xalan</artifactId>
+                                <version>${xalan.version}</version>
 			</dependency>
 
 			<!-- TIBCO dependencies -->
@@ -664,9 +685,9 @@
 			</dependency>
 			<!-- generated help mojo has a dependency to plexus-utils -->
 			<dependency>
-				<groupId>org.codehaus.plexus</groupId>
-				<artifactId>plexus-utils</artifactId>
-                <version>4.0.2</version>
+                                <groupId>org.codehaus.plexus</groupId>
+                                <artifactId>plexus-utils</artifactId>
+                <version>${plexus.utils.version}</version>
 			</dependency>
 
 			<!-- force version of this transitive dependencies to avoid this bug: 
@@ -705,19 +726,19 @@
 		</extensions>
 		<pluginManagement>
 			<plugins>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.14.1</version>
+                                <plugin>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-compiler-plugin</artifactId>
+                                        <version>${maven.compiler.plugin.version}</version>
 					<configuration>
 						<source>17</source>
 						<target>17</target>
 					</configuration>
 				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-deploy-plugin</artifactId>
-                    <version>3.1.4</version>
+                                <plugin>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-deploy-plugin</artifactId>
+                                        <version>${maven.deploy.plugin.version}</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -754,24 +775,24 @@
 						</execution>
 					</executions>
 				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-source-plugin</artifactId>
-                    <version>${maven.resources.source.plugin.version}</version>
+                                <plugin>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-source-plugin</artifactId>
+                                        <version>${maven.resources.source.plugin.version}</version>
 				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-resources-plugin</artifactId>
-                    <version>${maven.resources.source.plugin.version}</version>
+                                <plugin>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-resources-plugin</artifactId>
+                                        <version>${maven.resources.source.plugin.version}</version>
                     <configuration>
                         <encoding>UTF-8</encoding>
                         <propertiesEncoding>UTF-8</propertiesEncoding>
                     </configuration>
 				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-release-plugin</artifactId>
-                    <version>${maven.javadoc.plugin.version}</version>
+                                <plugin>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-release-plugin</artifactId>
+                                        <version>${maven.release.plugin.version}</version>
 					<configuration>
 						<autoVersionSubmodules>true</autoVersionSubmodules>
 						<tagNameFormat>@{project.version}</tagNameFormat>
@@ -780,10 +801,10 @@
 						<goals>deploy site-deploy</goals>
 					</configuration>
 				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.12.0</version>
+                                <plugin>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-javadoc-plugin</artifactId>
+                                        <version>${maven.javadoc.plugin.version}</version>
 					<configuration>
 						<detectLinks>true</detectLinks>
 						<detectOfflineLinks>false</detectOfflineLinks>
@@ -810,10 +831,10 @@
 					</configuration>
 				</plugin>
 
-				<plugin>
-					<groupId>com.mycila</groupId>
-					<artifactId>license-maven-plugin</artifactId>
-                    <version>5.0.0</version>
+                                <plugin>
+                                        <groupId>com.mycila</groupId>
+                                        <artifactId>license-maven-plugin</artifactId>
+                                        <version>${license.maven.plugin.version}</version>
 					<!-- http://code.google.com/p/maven-license-plugin/ -->
 					<configuration>
 						<aggregate>true</aggregate>
@@ -861,10 +882,10 @@
 					</configuration>
 				</plugin>
 
-				<plugin>
-                        <groupId>com.sun.xml.ws</groupId>
-                        <artifactId>jaxws-maven-plugin</artifactId>
-                        <version>4.0.3</version>
+                                <plugin>
+                                        <groupId>com.sun.xml.ws</groupId>
+                                        <artifactId>jaxws-maven-plugin</artifactId>
+                                        <version>${jaxws.maven.plugin.version}</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>
@@ -873,9 +894,9 @@
 				settings.xml or -D command line args instead of fixing these in the pom.xml 
 				which is shared among all projects and developpers. -->
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>3.6.1</version> <!-- Update for java 17-->
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-enforcer-plugin</artifactId>
+                                <version>${maven.enforcer.plugin.version}</version> <!-- Update for java 17-->
 				<executions>
 					<execution>
 						<id>enforce-property</id>


### PR DESCRIPTION
## Summary
- declare reusable dependency and plugin version properties in the root pom
- update plugin and dependency declarations to reference the shared properties

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e68877f5608328bb4667773d237fcd